### PR TITLE
ci: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,5 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: snapcore/action-build@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # 1.3.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: snapcore/action-build@v1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # 1.3.0
       id: build
-    - uses: snapcore/action-publish@v1
+    - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # 1.2.0
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,7 +18,7 @@ jobs:
          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
      - name: Checkout Repository
-       uses: actions/checkout@v4
+       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
      - name: Update manifest
        id: manifest


### PR DESCRIPTION
Update remaining workflow action references to resolve Node.js 20 deprecation warnings. Node.js 20 actions will be forced to run on Node.js 24 starting June 2nd, 2026.

Action version bumps:
- actions/checkout: v4 > v6.0.2
- snapcore/action-build: v1 > v1.3.0
- snapcore/action-publish: v1 > v1.2.0

Contributed on behalf of STMicroelectronics